### PR TITLE
Add dummy /api/predict and /api/news-feed endpoint

### DIFF
--- a/news_src/api/urls.py
+++ b/news_src/api/urls.py
@@ -2,5 +2,6 @@ from django.urls import path
 from . import views
 
 urlpatterns = [
-    path('predict', views.predict)
+    path('predict', views.predict),
+    path('news-feed', views.feed)
 ]

--- a/news_src/api/urls.py
+++ b/news_src/api/urls.py
@@ -1,0 +1,6 @@
+from django.urls import path
+from . import views
+
+urlpatterns = [
+    path('predict', views.predict)
+]

--- a/news_src/api/views.py
+++ b/news_src/api/views.py
@@ -1,14 +1,55 @@
+from json.decoder import JSONDecodeError
 from django.shortcuts import render
 from django.http import HttpResponse, JsonResponse
 import random
 import json
+import requests
+import os
+import datetime
+import time
+import logging
 
+PAGES_LOOKUP = 3
+REQUEST_WAIT_TIME = 0.5
+loggger = logging.getLogger('app_api')
 
 def predict(request):
-    body_unicode = request.body.decode('utf-8')
-    body = json.loads(body_unicode)
-    if 'title' not in body or 'selftext' not in body:
-        return JsonResponse({'error': 'Missing Parameters'})
+    try:
+        body_unicode = request.body.decode('utf-8')
+        body = json.loads(body_unicode)
+        if 'title' not in body or 'selftext' not in body:
+            return JsonResponse({'error': 'Missing Parameters'})
+    except JSONDecodeError as e:
+        return JsonResponse({'error': 'Parse body failure', 'msg': e.msg})
     proba = random.random()
     result = {'prediction': proba > 0.5, 'proba': proba}
+    loggger.debug(result)
     return JsonResponse(result)
+
+def feed(request):
+    today = datetime.datetime.now()
+    yesterday = today - datetime.timedelta(days=1)
+    return_feed = []
+    for page in range(1, PAGES_LOOKUP+1):
+        r = requests.get(f"https://newsapi.org/v2/everything?sources=cnn,fox-news,axios\
+                            &from={yesterday.isoformat()}&to={today.isoformat}&\
+                            language=en&page={page}&apiKey={os.environ['NEWS_API_KEY']}")
+        news_feed = r.json()
+        if not r.ok or news_feed["status"] != 'ok':
+            return JsonResponse({'error': 'External Service Error'})
+        __build_return_feed(news_feed, return_feed)
+        time.sleep(REQUEST_WAIT_TIME)
+    return JsonResponse({"count": len(return_feed), "feed": return_feed})
+
+def __build_return_feed(news_feed, return_feed):
+    for articles in news_feed['articles']:
+        #dummy prediction
+        proba = random.random()
+        return_feed.append(
+            {
+                "text": articles["content"] if articles["content"] is not None else articles["title"],
+                "url": articles["url"],
+                'prediction': proba > 0.5, 
+                'proba': proba
+            }
+        )

--- a/news_src/api/views.py
+++ b/news_src/api/views.py
@@ -1,0 +1,14 @@
+from django.shortcuts import render
+from django.http import HttpResponse, JsonResponse
+import random
+import json
+
+
+def predict(request):
+    body_unicode = request.body.decode('utf-8')
+    body = json.loads(body_unicode)
+    if 'title' not in body or 'selftext' not in body:
+        return JsonResponse({'error': 'Missing Parameters'})
+    proba = random.random()
+    result = {'prediction': proba > 0.5, 'proba': proba}
+    return JsonResponse(result)

--- a/news_src/news_src/settings.py
+++ b/news_src/news_src/settings.py
@@ -37,6 +37,7 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
+    'api'
 ]
 
 MIDDLEWARE = [

--- a/news_src/news_src/settings.py
+++ b/news_src/news_src/settings.py
@@ -119,3 +119,19 @@ USE_TZ = True
 # https://docs.djangoproject.com/en/3.1/howto/static-files/
 
 STATIC_URL = '/static/'
+
+LOGGING = {
+    'version': 1,
+    'disable_existing_loggers': False,
+    'handlers': {
+        'console': {
+            'class': 'logging.StreamHandler',
+        },
+    },
+    'loggers': {
+        'app_api': {
+            'handlers': ['console'],
+            'level': 'INFO',
+        },
+    },
+}

--- a/news_src/news_src/urls.py
+++ b/news_src/news_src/urls.py
@@ -14,8 +14,9 @@ Including another URLconf
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
 from django.contrib import admin
-from django.urls import path
+from django.urls import path, include
 
 urlpatterns = [
     path('admin/', admin.site.urls),
+    path('api/', include('api.urls'))
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ asgiref==3.3.1
 Django==3.1.7
 pytz==2021.1
 sqlparse==0.4.1
+requests


### PR DESCRIPTION
Adding a dummy /api/predict endpoint

return a random number between 0 and 1, with prediction >= 0.5 being true

Input

```json
{"title": title, "selftext": body, "optionals" : {"categories": cat}}
```

output
```
{“prediction”: “true/false”, “probability”: 0.1}
```
