### PR TITLE
Added /api/link-info

### DIFF
--- a/news_src/api/urls.py
+++ b/news_src/api/urls.py
@@ -3,5 +3,6 @@ from . import views
 
 urlpatterns = [
     path('predict', views.predict),
-    path('news-feed', views.feed)
+    path('news-feed', views.feed),
+    path('link-info', views.link_info)
 ]

--- a/news_src/api/views.py
+++ b/news_src/api/views.py
@@ -8,10 +8,12 @@ import os
 import datetime
 import time
 import logging
+import newsplease
 
 PAGES_LOOKUP = 3
 REQUEST_WAIT_TIME = 0.5
 loggger = logging.getLogger('app_api')
+TIMEOUT = 5 * 60 
 
 def predict(request):
     try:
@@ -53,3 +55,22 @@ def __build_return_feed(news_feed, return_feed):
                 'proba': proba
             }
         )
+
+def link_info(request):
+    try:
+        body_unicode = request.body.decode('utf-8')
+        body = json.loads(body_unicode)
+        if 'link' not in body:
+            return JsonResponse({'error': 'Missing Parameters'})
+    except JSONDecodeError as e:
+        return JsonResponse({'error': 'Parse body failure', 'msg': e.msg})
+    try:
+        article = newsplease.NewsPlease.from_url(url=body['link'], timeout=TIMEOUT)
+        return JsonResponse(
+            {
+                "title": article.title,
+                "body": article.maintext
+            })
+    except Exception:
+        return JsonResponse({'error': 'Timeout'})
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,7 @@ Django==3.1.7
 pytz==2021.1
 sqlparse==0.4.1
 requests
+numpy
+scipy
+news-please
+cchardet

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,6 @@ numpy
 scipy
 news-please
 cchardet
+djangorestframework
+markdown
+django-filter


### PR DESCRIPTION
Added new /api/link-info endpoint to get news title and body, allows for some error handling if sent the missing parameters, will return a json containing 

```json
{"error": "msg"}
```

Input

```json
{
    "link": "https://www.cnn.com/2021/03/05/us/pennsylvania-town-surprises-ups-driver-trnd/index.html"
}
```

Output:
```json
{
    "title": "Pennsylvania town surprised its UPS driver with a $1,000 gift",
    "body": "(CNN) A UPS driver was moved to tears after his customers ....
}
```