### PR TITLE
New Db speed up

### DIFF
--- a/news_src/api/core/models.py
+++ b/news_src/api/core/models.py
@@ -1,0 +1,10 @@
+from django.db import models
+from django.db.models.fields import BooleanField, CharField, FloatField, IntegerField, TextField, TimeField, URLField
+
+class News(models.Model):
+    id = IntegerField(primary_key=True)
+    text = TextField()
+    url = URLField()
+    image = URLField()
+    date_publish = TimeField()
+    source_domain = CharField(max_length=50)

--- a/news_src/api/core/news_scrape.py
+++ b/news_src/api/core/news_scrape.py
@@ -1,4 +1,5 @@
 import os
+from django.db import models
 import requests
 import json
 from bs4 import BeautifulSoup
@@ -10,6 +11,10 @@ import newsplease
 from newsplease import NewsArticle
 from requests.sessions import session
 from typing import List, Tuple
+import django
+django.setup()
+from .models import News
+from datetime import datetime
 
 loggger = logging.getLogger('app_api')
 
@@ -19,7 +24,24 @@ with open(os.path.join(os.path.dirname(__file__), "feed-config.json"), "rb") as 
     FEED_JSON = json.load(f)
 
 def _article(link: str):
-    article = newsplease.NewsPlease.from_url(url=link)
+    if News.objects.filter(url=link).exists():
+        news = News.objects.get(url=link)
+        article = newsplease.NewsPlease()
+        article.maintext = news.text
+        article.url = news.url
+        article.image_url = news.image
+        article.date_publish = news.date_publish
+        article.source_domain = news.source_domain
+    else:
+        article = newsplease.NewsPlease.from_url(url=link)
+        if article.maintext is None:
+            return
+        news = News(text=article.maintext, 
+                    url=article.url,
+                    image=article.image_url,
+                    date_publish=article.date_publish,
+                    source_domain=article.source_domain)
+        news.save()
     # print(article.title)
     # print(article.source_domain)
     return article
@@ -35,5 +57,5 @@ def news_feed() -> List[NewsArticle.NewsArticle]:
                         if link_pattern.match(link.text)]
     with Pool(processes=PROC_COUNT) as pool:
         articles = pool.map(_article, links)
-        articles = [article for article in articles if article.maintext is not None]
+        articles = [article for article in articles if article is not None and article.maintext is not None]
     return articles

--- a/news_src/api/views.py
+++ b/news_src/api/views.py
@@ -26,7 +26,7 @@ loggger = logging.getLogger('django')
 TIMEOUT = 5 * 60 
 PROC_COUNT = 3
 
-@api_view(['GET', 'POST'])
+@api_view(['POST'])
 def predict_text(request):
     input_ser = PredictionInputSerializer(data=request.data)
     if not input_ser.is_valid():
@@ -36,7 +36,7 @@ def predict_text(request):
     loggger.info(f"Prediction: {result}")
     return JsonResponse(result)
 
-@api_view(['GET', 'POST'])
+@api_view(['GET'])
 def feed(request):
     articles = news_feed()
     return_feed = _return_feed(articles)
@@ -73,7 +73,7 @@ def _return_feed(news_feed: List[NewsArticle.NewsArticle]):
             })
     return return_feed
 
-@api_view(['GET', 'POST'])
+@api_view(['POST'])
 def link_info(request):
     link_ser = LinkScrapeSerializer(data=request.data)
     if not link_ser.is_valid():

--- a/news_src/api/views.py
+++ b/news_src/api/views.py
@@ -31,8 +31,8 @@ def predict_text(request):
     input_ser = PredictionInputSerializer(data=request.data)
     if not input_ser.is_valid():
         return JsonResponse({'error': 'Missing Parameters'}, status=status.HTTP_400_BAD_REQUEST)
-    proba = random.random()
-    result = {'prediction': proba > 0.5, 'proba': proba}
+    labels, confs = predict([input_ser.validated_data["selftext"]])
+    result = {'prediction': "Fake" if labels[0] == 0 else "True", 'proba': confs[0]}
     loggger.info(f"Prediction: {result}")
     return JsonResponse(result)
 


### PR DESCRIPTION
Going from 1m30s to 11s using database caching, predict endpoint now uses real predictions

Limiting endpoints to POST for link-info and predict, limiting endpoints to GET for news-feed

To make the database work, run the following commands

```
python manage.py api makemigrations
python manage.py API migrate
```

Check if the News object has been added, and don't commit the python migrations file