### PR TITLE
Fix on prediction (text + title) and datepublish null problem

### DIFF
--- a/news_src/api/core/models.py
+++ b/news_src/api/core/models.py
@@ -1,10 +1,11 @@
 from django.db import models
-from django.db.models.fields import BooleanField, CharField, FloatField, IntegerField, TextField, TimeField, URLField
+from django.db.models.fields import BooleanField, CharField, DateTimeField, FloatField, IntegerField, TextField, TimeField, URLField
 
 class News(models.Model):
     id = IntegerField(primary_key=True)
     text = TextField()
+    title = TextField(default="")
     url = URLField(unique=True)
-    image = URLField()
-    date_publish = TimeField()
+    image = URLField(null=True)
+    date_publish = DateTimeField(null=True)
     source_domain = CharField(max_length=50)

--- a/news_src/api/core/news_scrape.py
+++ b/news_src/api/core/news_scrape.py
@@ -27,16 +27,18 @@ def _article(link: str):
     if News.objects.filter(url=link).exists():
         news = News.objects.get(url=link)
         article = newsplease.NewsPlease()
+        article.title = news.title
         article.maintext = news.text
         article.url = news.url
         article.image_url = news.image
-        article.date_publish = news.date_publish
+        article.date_publish = news.date_publish.isoformat() if news.date_publish is not None else ""
         article.source_domain = news.source_domain
     else:
         article = newsplease.NewsPlease.from_url(url=link)
         if article.maintext is None:
             return
         news = News(text=article.maintext, 
+                    title=article.title,
                     url=article.url,
                     image=article.image_url,
                     date_publish=article.date_publish,

--- a/news_src/news_src/settings.py
+++ b/news_src/news_src/settings.py
@@ -117,7 +117,7 @@ USE_I18N = True
 
 USE_L10N = True
 
-USE_TZ = True
+USE_TZ = False
 
 
 # Static files (CSS, JavaScript, Images)


### PR DESCRIPTION
Moving models.py back datetimefield, the problem with expecting a str or byte like object seems to be because news.date_publish is a datetime obj or None, which we can call isoformat on. 

Prediction now predicts on `title + " " + text`